### PR TITLE
Fix/palettes for many categories

### DIFF
--- a/R/paleta.R
+++ b/R/paleta.R
@@ -21,7 +21,12 @@ paleta <- function(name, n = NULL, alpha = NULL, reverse = FALSE,
     } else if(pal$type == "qualitative"){
       colors <- pal$colors
       if(n > pal$length){
-        colors <- c(pal$colors, lighten(pal$colors), lighten(lighten(pal$colors)))
+        colors <- pal$colors
+        extra_colors <- colors
+        while(n > length(colors)){
+          extra_colors <- lighten(extra_colors)
+          colors <- c(colors, extra_colors)
+        }
         warning("Recycling with ", recycle, " colors.")
       }
       colors <- colors[1:n]

--- a/tests/testthat/test-paletero.R
+++ b/tests/testthat/test-paletero.R
@@ -6,6 +6,13 @@ test_that("Paleta",{
   paleta("Set1", n = 5)
   expect_equal(paleta("Set1", n = 12), c(set1, lighten(set1)[1:3]))
 
+  # test extension for more categories
+  lighten1 <- lighten(set1)
+  lighten2 <- lighten(lighten1)
+  lighten3 <- lighten(lighten2)
+  lighten4 <- lighten(lighten3)
+  expect_equal(paleta("Set1", n = 34), c(set1, lighten1, lighten2, lighten3, lighten4)[1:34])
+
   paleta("RColorBrewer::Purples")
   paleta("magma")
 


### PR DESCRIPTION
Extend `paleta` function so that it extends the palette to the length of the domain (without the previous limit of three times the length of the palette).